### PR TITLE
Merge: 영풍문고 세부 코드 가져와서 재고 있는 서점 리스트 반환하기

### DIFF
--- a/stock.go
+++ b/stock.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
@@ -17,23 +18,39 @@ var kyoboStock [][]string
 var ypbookStock [][]string
 var aladinStock []string
 
+// func main() {
+// 	http.HandleFunc("/api/book/stock", getStockHandler)
+
+// 	fmt.Println("서버를 시작합니다. http://localhost:8080")
+// 	http.ListenAndServe(":8080", nil)
+// }
+
+// func getStockHandler(w http.ResponseWriter, r *http.Request) {
+// 	isbn := r.URL.Query().Get("isbn")
+// 	price := r.URL.Query().Get("price")
+
+// 	kyobo(isbn)
+// 	yp_book(isbn, price)
+// 	aladin(isbn)
+// }
+
 func main() {
 	lambda.Start(getStockHandler)
 }
 
-func getStockHandler(ctx context.Context, event map[string]string) (string, error) {
+func getStockHandler(ctx context.Context, event map[string]string) ([][]string, [][]string, []string) {
 	isbn := event["isbn"]
-	code := event["code"]
 	price := event["price"]
 
-	kyobo(isbn)
-	yp_book(code, price)
-	aladin(isbn)
+	kyoboStock := kyobo(isbn)
+	ypbookStock := yp_book(isbn, price)
+	aladinStock := aladin(isbn)
 
-	return "Lambda function executed successfully!", nil
+	return kyoboStock, ypbookStock, aladinStock
 }
 
-func kyobo(isbn string) {
+func kyobo(isbn string) [][]string {
+	var result [][]string
 	kyoboNumberSlice := []string{"01", "58", "15", "23", "41", "66", "33", "72", "68", "36", "46", "74", "29", "90", "56", "49", "70", "52", "13", "47", "42", "25", "38", "69", "57", "59", "87", "04", "02", "05", "24", "45", "39", "77", "31", "28", "34", "48", "43"}
 	kyoboNameSlice := []string{"광화문", "가든파이브", "강남", "건대", "동대문", "신도림 디큐브", "목동", "서울대", "수유", "영등포", "은평", "이화여대", "잠실", "천호", "청량리", "합정", "광교", "광교월드 스퀘어", "부천", "분당", "송도", "인천", "일산", "판교", "평촌", "경성대ㆍ 부경대", "광주상무", "대구", "대전", "부산", "세종", "센텀시티", "울산", "전북대", "전주", "창원", "천안", "칠곡", "해운대 팝업 스토어"}
 
@@ -68,16 +85,20 @@ func kyobo(isbn string) {
 		if strongTag.Length() > 0 {
 			stock := regexp.MustCompile("\\d+").FindString(strongTag.Text())
 			if stock != "0" {
-				kyoboStock = append(kyoboStock, []string{store, stock})
-				fmt.Printf("%s %s\n", store, stock)
+				result = append(result, []string{store, stock})
+				// fmt.Printf("%s %s\n", store, stock)
 			}
 		} else {
 			fmt.Printf("%s에서의 태그 오류 또는 재고 정보 없음\n", site)
 		}
 	}
+	return result
 }
 
-func yp_book(code string, price string) {
+func yp_book(isbn string, price string) [][]string {
+	var result [][]string
+	code := detailYP(isbn)
+
 	url := fmt.Sprintf("https://www.ypbooks.co.kr/ypbooks_mobile/sub/mBranchStockLoc.jsp?bookCd=%s&bookCost=%s", code, price)
 
 	resp, err := http.Get(url)
@@ -105,13 +126,60 @@ func yp_book(code string, price string) {
 
 	for store, stock := range ypbookList {
 		if stock != "0" {
-			ypbookStock = append(ypbookStock, []string{store, stock})
-			fmt.Printf("%s %s\n", store, stock)
+			result = append(result, []string{store, stock})
 		}
 	}
+	return result
 }
 
-func aladin(isbn string) {
+func detailYP(code string) string {
+	url := "https://www.ypbooks.co.kr/ypbooks/search/requestAjaxSearchTab.jsp"
+
+	data := strings.NewReader("query=" + code + "&collection=ALL&searchfield=ALL&showCnt=&sortField=RANK&notSoldOut=Y&catesearch=false&c1=&c2=&c3=&viewStyle=list&pageNum=1")
+
+	req, err := http.NewRequest("POST", url, data)
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println("Error sending request:", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error reading response:", err)
+	}
+
+	responseText := string(body)
+
+	result := extractString(responseText, `<input\s+name="checkboxCartBook"\s+[^>]*value="([^"]*)"[^>]*>`)
+
+	return result
+}
+
+func extractString(text, pattern string) string {
+	re := regexp.MustCompile(pattern)
+	match := re.FindStringSubmatch(text)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return ""
+}
+
+func extractNumber(text string) string {
+	re := regexp.MustCompile(`[^0-9]`)
+	return re.ReplaceAllString(text, "")
+}
+
+func aladin(isbn string) []string {
+	var result []string
 	url := fmt.Sprintf("https://www.aladin.co.kr/search/wsearchresult.aspx?SearchTarget=UsedStore&KeyTag=&SearchWord=%s", isbn)
 
 	resp, err := http.Get(url)
@@ -129,11 +197,9 @@ func aladin(isbn string) {
 		log.Fatal(err)
 	}
 
-	aladinList := make(map[string]string)
-
 	doc.Find("a.usedshop_off_text3").Each(func(_ int, element *goquery.Selection) {
 		storeName := strings.TrimSpace(element.Text())
-		aladinList[storeName] = "1"
-		fmt.Printf("%s \n", storeName)
+		result = append(result, storeName)
 	})
+	return result
 }


### PR DESCRIPTION
### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #3


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 우선 테스트용으로 http 통신으로 받아온 isbn과 price로 영풍문고의 세부코드를 가져옴
- 세부코드를 가져오면서 html 파싱을 위해 정규식 사용
- 각 서점의 재고를 [][]string, 혹은 []string으로 만들어 lambdaHandler함수에서 3개의 배열을 반환해줌



<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
